### PR TITLE
Fix authenticate request missing sw_version

### DIFF
--- a/src/SwagAppsystem/Authenticator.php
+++ b/src/SwagAppsystem/Authenticator.php
@@ -72,10 +72,7 @@ class Authenticator
         $shopSignature = $query['shopware-shop-signature'];
 
         unset($query['shopware-shop-signature']);
-        array_walk($query, function (&$value, $key) {
-            $value = "{$key}={$value}";
-        });
-        $queryString = implode('&', $query);
+        $queryString = http_build_query($query);
 
         $hmac = \hash_hmac('sha256', $queryString, $shopSecret);
 

--- a/src/SwagAppsystem/Authenticator.php
+++ b/src/SwagAppsystem/Authenticator.php
@@ -69,16 +69,16 @@ class Authenticator
     public static function authenticateGetRequest(Request $request, string $shopSecret): bool
     {
         $query = $request->query->all();
+        $shopSignature = $query['shopware-shop-signature'];
 
-        $queryString = sprintf(
-            'shop-id=%s&shop-url=%s&timestamp=%s',
-            $query['shop-id'],
-            $query['shop-url'],
-            $query['timestamp']
-        );
+        unset($query['shopware-shop-signature']);
+        array_walk($query, function (&$value, $key) {
+            $value = "{$key}={$value}";
+        });
+        $queryString = implode('&', $query);
 
         $hmac = \hash_hmac('sha256', $queryString, $shopSecret);
 
-        return hash_equals($hmac, $query['shopware-shop-signature']);
+        return hash_equals($hmac, $shopSignature);
     }
 }


### PR DESCRIPTION
**Shopware version:** 6.4.2.1
**Description:** The app failed to authenticate get request because there is new query param "sw_version".
**Solution:** Include "sw_version" param to hash data.
